### PR TITLE
Minor fix for variable naming convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ var data = [
   const options = { 
     fieldSeparator: ',',
     quoteStrings: '"',
-    decimalseparator: '.',
+    decimalSeparator: '.',
     showLabels: true, 
     showTitle: true,
     title: 'My Awesome CSV',
@@ -66,7 +66,7 @@ csvExporter.generateCsv(data);
 | **fieldSeparator**      | , | Defines the field separator character |
 | **filename**      | 'generated' | Sets the name of the downloaded file. ".csv" will be appended to the value provided. |
 | **quoteStrings**      | "      | If provided, will use this characters to "escape" fields, otherwise will use double quotes as deafult |
-| **decimalseparator** | .      | Defines the decimal separator character (default is .). If set to "locale", it uses the [language sensitive representation of the number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toLocaleString).|
+| **decimalSeparator** | .      | Defines the decimal separator character (default is .). If set to "locale", it uses the [language sensitive representation of the number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toLocaleString).|
 | **showLabels** | false      | If true, the first row will be the `headers` option or object keys if `useKeysAsHeaders` is present|
 | **showTitle** | false      | Includes the title as the first line in the generated file   |
 | **title** | 'My Generated Report' | This string will be used as the report title |

--- a/export-to-csv.ts
+++ b/export-to-csv.ts
@@ -2,7 +2,7 @@ export interface Options {
     filename?: string;
     fieldSeparator?: string;
     quoteStrings?: string;
-    decimalseparator?: string;
+    decimalSeparator?: string;
     showLabels?: boolean;
     showTitle?: boolean;
     title?: string;
@@ -33,7 +33,7 @@ export const ConfigDefaults: Options = {
     filename: CsvConfigConsts.DEFAULT_FILENAME,
     fieldSeparator: CsvConfigConsts.DEFAULT_FIELD_SEPARATOR,
     quoteStrings: CsvConfigConsts.DEFAULT_QUOTE,
-    decimalseparator: CsvConfigConsts.DEFAULT_DECIMAL_SEPARATOR,
+    decimalSeparator: CsvConfigConsts.DEFAULT_DECIMAL_SEPARATOR,
     showLabels: CsvConfigConsts.DEFAULT_SHOW_LABELS,
     showTitle: CsvConfigConsts.DEFAULT_SHOW_TITLE,
     title: CsvConfigConsts.DEFAULT_TITLE,
@@ -165,12 +165,12 @@ export class ExportToCsv {
      */
     private _formatData(data: any) {
 
-        if (this._options.decimalseparator === 'locale' && this._isFloat(data)) {
+        if (this._options.decimalSeparator === 'locale' && this._isFloat(data)) {
             return data.toLocaleString();
         }
 
-        if (this._options.decimalseparator !== '.' && this._isFloat(data)) {
-            return data.toString().replace('.', this._options.decimalseparator);
+        if (this._options.decimalSeparator !== '.' && this._isFloat(data)) {
+            return data.toString().replace('.', this._options.decimalSeparator);
         }
 
         if (typeof data === 'string') {


### PR DESCRIPTION
I've changed a naming of variable to follow the same camel case formation through out the library and made it's API reference same as others.