### PR TITLE
Adds useBlanksForUndefined option

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ var data = [
     useTextFile: false,
     useBom: true,
     useKeysAsHeaders: true,
+    useBlanksForUndefined: true
     // headers: ['Column 1', 'Column 2', etc...] <-- Won't work with useKeysAsHeaders present!
   };
 
@@ -75,6 +76,7 @@ csvExporter.generateCsv(data);
 | **useTextFile** | false      | If true, returns a `.txt` file instead of `.csv` |
 | **useKeysAsHeaders** | false      | If true, this will use the keys of the first object in the collection as the column headers|
 | **headers** | []      | Expects an array of strings, which if supplied, will be used as the column headers|
+| **useBlanksForUndefined** | false | If true, undefined or null values are omitted from the csv, resulting output like `Value 1,,Value 3`
 
 
 # Thanks!

--- a/export-to-csv.spec.ts
+++ b/export-to-csv.spec.ts
@@ -54,7 +54,7 @@ describe('ExportToCsv', () => {
             description: "Test 5 description"
         });
         const string = exportToCsvInstance.generateCsv(data, true);
-        console.log(string);
+
         expect(string).toBeTruthy(typeof string === 'string');
         expect(string).toContain(",,");
         expect(string).not.toContain("undefined");

--- a/export-to-csv.spec.ts
+++ b/export-to-csv.spec.ts
@@ -37,6 +37,29 @@ describe('ExportToCsv', () => {
         expect(string).toBeTruthy(typeof string === 'string');
     });
 
+    it ('should use blank string when data value is null or undefined', () => {
+        const options: Options = {
+            title: "Test Csv",
+            useBom: true,
+            useKeysAsHeaders: true,
+            useBlanksForUndefined: true
+        }
+
+        const exportToCsvInstance = new ExportToCsv(options);
+        const data = JSON.parse(JSON.stringify(mockData));
+        data.push( {
+            name: 'Test 5',
+            average: 9.2,
+            approved: false,
+            description: "Test 5 description"
+        });
+        const string = exportToCsvInstance.generateCsv(data, true);
+        console.log(string);
+        expect(string).toBeTruthy(typeof string === 'string');
+        expect(string).toContain(",,");
+        expect(string).not.toContain("undefined");
+    });
+
     it('should use keys of first object in collection as headers', () => {
         const options: Options = {
             title: "Test Csv",

--- a/export-to-csv.ts
+++ b/export-to-csv.ts
@@ -10,6 +10,7 @@ export interface Options {
     useBom?: boolean;
     headers?: string[];
     useKeysAsHeaders?: boolean;
+    useBlanksForUndefined?: boolean;
 }
 
 export class CsvConfigConsts {
@@ -28,6 +29,7 @@ export class CsvConfigConsts {
     public static DEFAULT_USE_BOM = true;
     public static DEFAULT_HEADER: string[] = [];
     public static DEFAULT_KEYS_AS_HEADERS = false;
+    public static DEFAULT_USE_BLANKS_FOR_UNDEFINED = false;
 
 }
 
@@ -43,6 +45,7 @@ export const ConfigDefaults: Options = {
     useBom: CsvConfigConsts.DEFAULT_USE_BOM,
     headers: CsvConfigConsts.DEFAULT_HEADER,
     useKeysAsHeaders: CsvConfigConsts.DEFAULT_KEYS_AS_HEADERS,
+    useBlanksForUndefined: CsvConfigConsts.DEFAULT_USE_BLANKS_FOR_UNDEFINED
 };
 export class ExportToCsv {
 
@@ -171,6 +174,10 @@ export class ExportToCsv {
      */
     private _formatData(data: any) {
 
+        if (this._options.useBlanksForUndefined && !data ) {
+            return "";
+        }
+
         if (this._options.decimalSeparator === 'locale' && this._isFloat(data)) {
             return data.toLocaleString();
         }
@@ -201,10 +208,10 @@ export class ExportToCsv {
     }
     /**
      * Parse the collection given to it
-     * 
+     *
      * @private
-     * @param {*} jsonData 
-     * @returns {any[]} 
+     * @param {*} jsonData
+     * @returns {any[]}
      * @memberof ExportToCsv
      */
     private _parseData(jsonData: any): any[] {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
         "karma-jasmine": "^1.0.2",
         "karma-phantomjs-launcher": "^1.0.4",
         "karma-sourcemap-loader": "^0.3.7",
-        "karma-typescript": "^3.0.8",
+        "karma-typescript": "^5.0.3",
         "typescript": "~2.4.0"
     }
 }


### PR DESCRIPTION
When generating a CSV from data with set headers but sometimes missing data, `undefined` and `null` is used to represent the missing data. 

I've added the option to use empty strings instead of `null` and `undefined` as referenced here: #11 