### PR TITLE
Fix formatting not using fieldSeparator option

### DIFF
--- a/export-to-csv.ts
+++ b/export-to-csv.ts
@@ -181,7 +181,7 @@ export class ExportToCsv {
 
         if (typeof data === 'string') {
             data = data.replace(/"/g, '""');
-            if (this._options.quoteStrings || data.indexOf(',') > -1 || data.indexOf('\n') > -1 || data.indexOf('\r') > -1) {
+            if (this._options.quoteStrings || data.indexOf(this._options.fieldSeparator) > -1 || data.indexOf('\n') > -1 || data.indexOf('\r') > -1) {
                 data = this._options.quoteStrings + data + this._options.quoteStrings;
             }
             return data;


### PR DESCRIPTION
_formatData is not using fieldSeparator option when checking for separators