### PR TITLE
Add option to use display labels with columnHeaders

### DIFF
--- a/lib/__specs__/helpers.spec.ts
+++ b/lib/__specs__/helpers.spec.ts
@@ -159,6 +159,19 @@ describe("Helpers", () => {
         expect(dateAndCity).toEqual('"date","city"' + endOfLine);
       });
     });
+
+    describe("pretty header mappings", () => {
+      it("should allow columnHeaders to contain objects with a display label", () => {
+        const config = mkConfig({
+          columnHeaders: ["name", { key: "date", displayLabel: "Date" }],
+        });
+        const nameAndDate = addHeaders(config, [
+          "name",
+          { key: "date", displayLabel: "Date" },
+        ])(mkCsvOutput(""));
+        expect(nameAndDate).toEqual('"name","Date"' + endOfLine);
+      });
+    });
   });
 
   describe("addBody", () => {
@@ -167,6 +180,16 @@ describe("Helpers", () => {
       const nameAndDate = addBody(
         config,
         ["name", "date"],
+        [{ name: "rouky", date: "2023-09-02" }],
+      )(mkCsvOutput(""));
+      expect(nameAndDate).toEqual('"rouky","2023-09-02"' + endOfLine);
+    });
+
+    it("should build csv body with pretty headers", () => {
+      const config = mkConfig({});
+      const nameAndDate = addBody(
+        config,
+        ["name", { key: "date", displayLabel: "Date" }],
         [{ name: "rouky", date: "2023-09-02" }],
       )(mkCsvOutput(""));
       expect(nameAndDate).toEqual('"rouky","2023-09-02"' + endOfLine);

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -5,6 +5,8 @@ export type Newtype<URI, A> = {
 
 export type WithDefaults<T> = Required<T>;
 
+export type ColumnHeader = string | { key: string; displayLabel: string };
+
 export type ConfigOptions = {
   filename?: string;
   fieldSeparator?: string;
@@ -16,14 +18,20 @@ export type ConfigOptions = {
   title?: string;
   useTextFile?: boolean;
   useBom?: boolean;
-  columnHeaders?: Array<string>;
+  columnHeaders?: Array<ColumnHeader>;
   useKeysAsHeaders?: boolean;
   boolDisplay?: { true: string; false: string };
   replaceUndefinedWith?: string | boolean | null;
 };
 
-export interface CsvOutput
-  extends Newtype<{ readonly CsvOutput: unique symbol }, string> {}
+export type HeaderKey = Newtype<{ readonly HeaderKey: unique symbol }, string>;
+
+export type HeaderDisplayLabel = Newtype<
+  { readonly HeaderDisplayLabel: unique symbol },
+  string
+>;
+
+export type CsvOutput = Newtype<{ readonly CsvOutput: unique symbol }, string>;
 
 export type CsvRow = Newtype<{ readonly CsvRow: unique symbol }, string>;
 
@@ -37,3 +45,5 @@ export const unpack = <T extends Newtype<any, any>>(newtype: T): T["_A"] =>
 
 export const mkCsvOutput = pack<CsvOutput>;
 export const mkCsvRow = pack<CsvRow>;
+export const mkHeaderKey = pack<HeaderKey>;
+export const mkHeaderDisplayLabel = pack<HeaderDisplayLabel>;


### PR DESCRIPTION
A slightly more ergonomic way to have "pretty headers" for an exported CSV without having to fully transform your data before passing it to the library.

This can be done on a per-column basis.