### PR TITLE
Add build step to PR workflow

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,6 +6,19 @@ on:
 
 jobs:
   build:
+    timeout-minutes: 5
+    name: Build project
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run build step
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: latest
+      - run: bun install --frozen-lockfile
+      - run: bun run build
+  tests:
     timeout-minutes: 60
     name: Unit & E2E Tests
     # The type of runner that the job will run on


### PR DESCRIPTION
This ensures the project still builds and typechecks correctly.