### PR TITLE
Improve typing

### DIFF
--- a/integration/index.html
+++ b/integration/index.html
@@ -25,12 +25,14 @@
           date: "2023-09-01",
           percentage: 0.4,
           quoted: '"Pickles"',
+          nullish: null,
         },
         {
           name: "Keiko",
           date: "2023-09-01",
           percentage: 0.9,
           quoted: '"Cactus"',
+          nullish: "test",
         },
       ];
 

--- a/lib/__specs__/helpers.spec.ts
+++ b/lib/__specs__/helpers.spec.ts
@@ -12,7 +12,7 @@ import {
   thread,
 } from "../helpers.ts";
 import { byteOrderMark, endOfLine, mkConfig } from "../config.ts";
-import { mkCsvOutput, mkCsvRow, unpack } from "../types.ts";
+import { mkCsvOutput, mkCsvRow, mkFormattedData, unpack } from "../types.ts";
 
 describe("Helpers", () => {
   describe("thread", () => {
@@ -119,7 +119,9 @@ describe("Helpers", () => {
     it("should add item to row", () => {
       const config = mkConfig({});
       const input = mkCsvRow("test,one,two,");
-      const output = asString(buildRow(config)(input, "house"));
+      const output = asString(
+        buildRow(config)(input, mkFormattedData("house")),
+      );
 
       expect(output).toBe("test,one,two,house,");
     });
@@ -208,7 +210,7 @@ describe("Helpers", () => {
         decimalSeparator: "locale",
       });
       const formatted = formatData(config, 0.6);
-      expect(formatted).toEqual((0.6).toLocaleString());
+      expect(formatted).toEqual(mkFormattedData((0.6).toLocaleString()));
     });
 
     it("should use custom decimal separator if set", () => {
@@ -216,24 +218,24 @@ describe("Helpers", () => {
         decimalSeparator: "|",
       });
       const formatted = formatData(config, 0.6);
-      expect(formatted).toEqual("0|6");
+      expect(formatted).toEqual(mkFormattedData("0|6"));
     });
 
     it("should properly quote strings that may conflict with generation", () => {
       // Default case should quote stings
       let config = mkConfig({});
       const defaultQuote = formatData(config, "test");
-      expect(defaultQuote).toEqual('"test"');
+      expect(defaultQuote).toEqual(mkFormattedData('"test"'));
 
       // Use custom quote strings
       config = mkConfig({ quoteCharacter: "^" });
       const customQuotes = formatData(config, "test");
-      expect(customQuotes).toEqual("^test^");
+      expect(customQuotes).toEqual(mkFormattedData("^test^"));
 
       // Disable quoting strings
       config = mkConfig({ quoteStrings: false });
       const disableQuotes = formatData(config, "test");
-      expect(disableQuotes).toEqual("test");
+      expect(disableQuotes).toEqual(mkFormattedData("test"));
     });
 
     describe("force quote problem characters", () => {
@@ -241,22 +243,22 @@ describe("Helpers", () => {
         // Quote field separator
         let config = mkConfig({ quoteStrings: false });
         const customQuote = formatData(config, ",");
-        expect(customQuote).toEqual('","');
+        expect(customQuote).toEqual(mkFormattedData('","'));
 
         // Wrap new line
         config = mkConfig({ quoteStrings: false });
         const wrapNewLine = formatData(config, "test\n");
-        expect(wrapNewLine).toEqual('"test\n"');
+        expect(wrapNewLine).toEqual(mkFormattedData('"test\n"'));
 
         // Wrap carrage return
         config = mkConfig({ quoteStrings: false });
         const wrapCR = formatData(config, "test\r");
-        expect(wrapCR).toEqual('"test\r"');
+        expect(wrapCR).toEqual(mkFormattedData('"test\r"'));
 
         // Force quote with custom character
         config = mkConfig({ quoteStrings: false, quoteCharacter: "|" });
         const wrapCRWithCustom = formatData(config, "test\r");
-        expect(wrapCRWithCustom).toEqual("|test\r|");
+        expect(wrapCRWithCustom).toEqual(mkFormattedData("|test\r|"));
       });
     });
   });

--- a/lib/__specs__/main.spec.ts
+++ b/lib/__specs__/main.spec.ts
@@ -181,7 +181,7 @@ describe("ExportToCsv", () => {
       useBom: false,
       showColumnHeaders: true,
       useKeysAsHeaders: true,
-      replaceUndefinedWith: "TEST"
+      replaceUndefinedWith: "TEST",
     };
 
     const output = asString(
@@ -437,7 +437,7 @@ describe("ExportToCsv As A Text File", () => {
       useBom: false,
       showColumnHeaders: true,
       useKeysAsHeaders: true,
-      replaceUndefinedWith: "TEST"
+      replaceUndefinedWith: "TEST",
     };
 
     const output = asString(

--- a/lib/__specs__/main.spec.ts
+++ b/lib/__specs__/main.spec.ts
@@ -147,7 +147,7 @@ describe("ExportToCsv", () => {
       ]),
     );
 
-    expect(output).toBe('"non-null","nullish"\r\n24,null\r\n');
+    expect(output).toBe('"non-null","nullish"\r\n24,"null"\r\n');
   });
 
   it("should convert undefined to empty string by default", () => {
@@ -375,7 +375,7 @@ describe("ExportToCsv As A Text File", () => {
       ]),
     );
 
-    expect(output).toBe('"non-null","nullish"\r\n24,null\r\n');
+    expect(output).toBe('"non-null","nullish"\r\n24,"null"\r\n');
   });
 
   it("should convert undefined to empty string by default", () => {

--- a/lib/__specs__/main.spec.ts
+++ b/lib/__specs__/main.spec.ts
@@ -175,6 +175,32 @@ describe("ExportToCsv", () => {
     );
   });
 
+  it("should replace undefined with specified value", () => {
+    const options: ConfigOptions = {
+      filename: "Test Csv 2",
+      useBom: false,
+      showColumnHeaders: true,
+      useKeysAsHeaders: true,
+      replaceUndefinedWith: "TEST"
+    };
+
+    const output = asString(
+      generateCsv(options)([
+        {
+          car: "toyota",
+          color: "blue",
+        },
+        {
+          car: "chevrolet",
+        },
+      ]),
+    );
+
+    expect(output).toBe(
+      '"car","color"\r\n"toyota","blue"\r\n"chevrolet","TEST"\r\n',
+    );
+  });
+
   it("should handle varying data shapes by manually setting column headers", () => {
     const options: ConfigOptions = {
       filename: "Test Csv 2",
@@ -401,6 +427,33 @@ describe("ExportToCsv As A Text File", () => {
 
     expect(output).toBe(
       '"car","color"\r\n"toyota","blue"\r\n"chevrolet",""\r\n',
+    );
+  });
+
+  it("should replace undefined with specified value", () => {
+    const options: ConfigOptions = {
+      filename: "Test Csv 2",
+      useTextFile: true,
+      useBom: false,
+      showColumnHeaders: true,
+      useKeysAsHeaders: true,
+      replaceUndefinedWith: "TEST"
+    };
+
+    const output = asString(
+      generateCsv(options)([
+        {
+          car: "toyota",
+          color: "blue",
+        },
+        {
+          car: "chevrolet",
+        },
+      ]),
+    );
+
+    expect(output).toBe(
+      '"car","color"\r\n"toyota","blue"\r\n"chevrolet","TEST"\r\n',
     );
   });
 

--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -18,3 +18,10 @@ export class CsvDownloadEnvironmentError extends Error {
     this.name = "CsvDownloadEnvironmentError";
   }
 }
+
+export class UnsupportedDataFormatError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "UnsupportedDataFormatError";
+  }
+}

--- a/lib/generator.ts
+++ b/lib/generator.ts
@@ -5,7 +5,14 @@
 import { mkConfig } from "./config.ts";
 import { CsvDownloadEnvironmentError, CsvGenerationError } from "./errors.ts";
 import { addBOM, addBody, addHeaders, addTitle, thread } from "./helpers.ts";
-import { CsvOutput, ConfigOptions, IO, mkCsvOutput, unpack } from "./types.ts";
+import {
+  CsvOutput,
+  ConfigOptions,
+  IO,
+  mkCsvOutput,
+  unpack,
+  AcceptedData,
+} from "./types.ts";
 
 /**
  *
@@ -19,7 +26,13 @@ import { CsvOutput, ConfigOptions, IO, mkCsvOutput, unpack } from "./types.ts";
  */
 export const generateCsv =
   (config: ConfigOptions) =>
-  <T extends { [k: string | number]: unknown }>(data: Array<T>): CsvOutput => {
+  <
+    T extends {
+      [k: string | number]: AcceptedData;
+    },
+  >(
+    data: Array<T>,
+  ): CsvOutput => {
     const withDefaults = mkConfig(config);
     const headers = withDefaults.useKeysAsHeaders
       ? Object.keys(data[0])

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -31,6 +31,12 @@ export type HeaderDisplayLabel = Newtype<
   string
 >;
 
+export type AcceptedData = number | string | boolean | null | undefined;
+export type FormattedData = Newtype<
+  { readonly FormattedData: unique symbol },
+  string
+>;
+
 export type CsvOutput = Newtype<{ readonly CsvOutput: unique symbol }, string>;
 
 export type CsvRow = Newtype<{ readonly CsvRow: unique symbol }, string>;
@@ -43,6 +49,7 @@ export const pack = <T extends Newtype<any, any>>(value: T["_A"]): T =>
 export const unpack = <T extends Newtype<any, any>>(newtype: T): T["_A"] =>
   newtype as any as T["_A"];
 
+export const mkFormattedData = pack<FormattedData>;
 export const mkCsvOutput = pack<CsvOutput>;
 export const mkCsvRow = pack<CsvRow>;
 export const mkHeaderKey = pack<HeaderKey>;


### PR DESCRIPTION
Instead of using `any` and `unknown` with `formatData`, I wanted stricter type safety within the library code.

`formatData` will also now throw `UnsupportedDataFormatError` if it gets something other than a primitive data type (which can be seen under `AcceptedData` in `types.ts`. It should be up to the caller of the library to make sure their data is transformed correctly before generating a CSV with it.