### PR TITLE
Add tests to ensure spaces in headers and values are allowed

### DIFF
--- a/integration/index.html
+++ b/integration/index.html
@@ -26,6 +26,7 @@
           percentage: 0.4,
           quoted: '"Pickles"',
           nullish: null,
+          "string with spaces as header": "value with spaces",
         },
         {
           name: "Keiko",
@@ -33,6 +34,7 @@
           percentage: 0.9,
           quoted: '"Cactus"',
           nullish: "test",
+          "string with spaces as header": "more spaces",
         },
       ];
 
@@ -56,6 +58,7 @@
       );
     </script>
   </head>
+
   <body>
     <h1>Export to CSV testing</h1>
     <button id="csv">Download as CSV</button>

--- a/lib/__specs__/main.spec.ts
+++ b/lib/__specs__/main.spec.ts
@@ -43,6 +43,38 @@ describe("ExportToCsv", () => {
     expect(typeof string === "string").toBeTruthy();
   });
 
+  it("should allow keys with spaces", () => {
+    const mockDataOne = [
+      {
+        "Hello world": "test",
+        "this is another string with many spaces": 10,
+      },
+    ];
+
+    const optionsOne = mkConfig({ useBom: false, useKeysAsHeaders: true });
+    const stringOne = asString(generateCsv(optionsOne)(mockDataOne));
+    expect(stringOne).toEqual(
+      '"Hello world","this is another string with many spaces"\r\n"test",10\r\n',
+    );
+
+    const mockDataTwo = [
+      {
+        "Hello world": "test",
+        "this is another string with many spaces": 10,
+      },
+    ];
+
+    const optionsTwo = mkConfig({
+      useBom: false,
+      showColumnHeaders: true,
+      columnHeaders: ["Hello world", "this is another string with many spaces"],
+    });
+    const stringTwo = asString(generateCsv(optionsTwo)(mockDataTwo));
+    expect(stringTwo).toEqual(
+      '"Hello world","this is another string with many spaces"\r\n"test",10\r\n',
+    );
+  });
+
   it("should use fieldSeparator if supplied", () => {
     const options: ConfigOptions = {
       title: "Test Csv",


### PR DESCRIPTION
Inspired by #101. There were no test cases to ensure that spaces were allowed in headers and values.

Adding the cases passed green without change to library functions. Same for validating the output of the manual integration test.