### PR TITLE
Update .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -22,6 +22,7 @@ lib/**/*.d.ts
 build
 *.lock
 bun.lockb
+bunfig.toml
 
 # Editor files
 .prettierrc.json
@@ -35,3 +36,6 @@ tsconfig.*
 playwright*
 test-results
 coverage
+
+# nix files
+*.nix


### PR DESCRIPTION
We don't need to package nix files or `bunfig.toml` in future releases.