### PR TITLE
Add weztermocil config

### DIFF
--- a/.weztermocil/watch.yml
+++ b/.weztermocil/watch.yml
@@ -1,0 +1,8 @@
+windows:
+  - name: export-to-csv-watch
+    root: .
+    layout: tiled
+    panes:
+      - bun run test -- --watch
+      - bun run watch
+      - bun run tsc --watch

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "scripts": {
     "build": "rm -rf output && bun build index.ts --outdir ./output --minify && tsc",
+    "watch": "rm -rf output && bun build index.ts --outdir ./output --minify --watch",
     "e2e": "rm -rf integration/export-to-csv.js && bun run build && cp output/index.js integration/export-to-csv.js && playwright test",
     "e2e-ci": "rm -rf integration/export-to-csv.js && bun run build && cp output/index.js integration/export-to-csv.js && bunx playwright install --with-deps && playwright test",
     "e2e-server": "bunx http-server ./integration -p 3000",


### PR DESCRIPTION
Easily spin up a wezterm window that runs tests and build in a watch config.