### PR TITLE
Option to help guard against CWE-1236

### DIFF
--- a/integration/index.html
+++ b/integration/index.html
@@ -29,6 +29,15 @@
         delimiter: "\t",
         filename: "Best CSV as TSV",
       });
+      const csvConfigEscapeFormulas = mkConfig({
+        useKeysAsHeaders: true,
+        escapeFormulas: true,
+        filename: "Best CSV Escaped Formulas",
+      });
+      const csvConfigNoEscapeFormulas = mkConfig({
+        useKeysAsHeaders: true,
+        filename: "Best CSV Unescaped Formulas",
+      });
 
       const mockData = [
         {
@@ -49,12 +58,27 @@
         },
       ];
 
+      const formulaData = [
+        {
+          name: "=1+2",
+          note: "+cmd|' /C calc'!A0",
+          other: "-2+3",
+          atFormula: "@SUM(A1:A2)",
+        },
+      ];
+
       const csv = generateCsv(csvConfig)(mockData);
       const txt = generateCsv(txtConfig)(mockData);
       const tsv = generateCsv(tsvConfig)(mockData);
       const csvCustomFilename = generateCsv(csvConfig)(mockData);
       const txtCustomFilename = generateCsv(txtConfig)(mockData);
       const tsvCustomFilename = generateCsv(tsvConfig)(mockData);
+      const csvEscapeFormulas = generateCsv(csvConfigEscapeFormulas)(
+        formulaData,
+      );
+      const csvNoEscapeFormulas = generateCsv(csvConfigNoEscapeFormulas)(
+        formulaData,
+      );
 
       const csvBtn = document.querySelector("#csv");
       const txtBtn = document.querySelector("#txt");
@@ -62,6 +86,12 @@
       const csvBtnCustom = document.querySelector("#csv-custom");
       const txtBtnCustom = document.querySelector("#txt-custom");
       const tsvBtnCustom = document.querySelector("#tsv-custom");
+      const csvBtnEscapeFormulas = document.querySelector(
+        "#csv-escape-formulas",
+      );
+      const csvBtnNoEscapeFormulas = document.querySelector(
+        "#csv-no-escape-formulas",
+      );
 
       csvBtn.addEventListener("click", () => download(csvConfig)(csv));
       txtBtn.addEventListener("click", () => download(txtConfig)(txt));
@@ -75,6 +105,12 @@
       tsvBtnCustom.addEventListener("click", () =>
         download(tsvConfigCustomFilename)(tsvCustomFilename),
       );
+      csvBtnEscapeFormulas.addEventListener("click", () =>
+        download(csvConfigEscapeFormulas)(csvEscapeFormulas),
+      );
+      csvBtnNoEscapeFormulas.addEventListener("click", () =>
+        download(csvConfigNoEscapeFormulas)(csvNoEscapeFormulas),
+      );
     </script>
   </head>
 
@@ -87,6 +123,12 @@
     <button id="txt-custom">Download as TXT (custom filename)</button>
     <button id="tsv-custom">
       Download as TSV (custom filename and extension)
+    </button>
+    <button id="csv-escape-formulas">
+      Download as CSV (escape formulas)
+    </button>
+    <button id="csv-no-escape-formulas">
+      Download as CSV (formulas not escaped)
     </button>
   </body>
 </html>

--- a/integration/index.html
+++ b/integration/index.html
@@ -124,9 +124,7 @@
     <button id="tsv-custom">
       Download as TSV (custom filename and extension)
     </button>
-    <button id="csv-escape-formulas">
-      Download as CSV (escape formulas)
-    </button>
+    <button id="csv-escape-formulas">Download as CSV (escape formulas)</button>
     <button id="csv-no-escape-formulas">
       Download as CSV (formulas not escaped)
     </button>

--- a/integration/integration.spec.ts
+++ b/integration/integration.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from "@playwright/test";
+import { readFileSync } from "node:fs";
 
 test("download csv file (default filename)", async ({ page }) => {
   await page.goto("http://127.0.0.1:3000");
@@ -82,4 +83,54 @@ test("download tsv file (custom filename and extension)", async ({ page }) => {
 
   // assert filename
   expect(download.suggestedFilename()).toBe("Best CSV as TSV.tsv");
+});
+
+test("download csv file with escapeFormulas prefixes formula-triggering values", async ({
+  page,
+}) => {
+  await page.goto("http://127.0.0.1:3000");
+
+  const [download] = await Promise.all([
+    page.waitForEvent("download"),
+    page.locator("button#csv-escape-formulas").click(),
+  ]);
+
+  expect(download.suggestedFilename()).toBe(
+    "Best CSV Escaped Formulas.csv",
+  );
+
+  const path = await download.path();
+  const content = readFileSync(path, "utf-8");
+
+  expect(content).toContain('"\'=1+2"');
+  expect(content).toContain("\"'+cmd|' /C calc'!A0\"");
+  expect(content).toContain('"\'-2+3"');
+  expect(content).toContain('"\'@SUM(A1:A2)"');
+
+  // Should not contain the raw, unescaped formulas
+  expect(content).not.toContain('"=1+2"');
+  expect(content).not.toContain('"-2+3"');
+  expect(content).not.toContain('"@SUM(A1:A2)"');
+});
+
+test("download csv file without escapeFormulas leaves formula-triggering values untouched", async ({
+  page,
+}) => {
+  await page.goto("http://127.0.0.1:3000");
+
+  const [download] = await Promise.all([
+    page.waitForEvent("download"),
+    page.locator("button#csv-no-escape-formulas").click(),
+  ]);
+
+  expect(download.suggestedFilename()).toBe(
+    "Best CSV Unescaped Formulas.csv",
+  );
+
+  const path = await download.path();
+  const content = readFileSync(path, "utf-8");
+
+  expect(content).toContain('"=1+2"');
+  expect(content).toContain('"-2+3"');
+  expect(content).toContain('"@SUM(A1:A2)"');
 });

--- a/integration/integration.spec.ts
+++ b/integration/integration.spec.ts
@@ -95,9 +95,7 @@ test("download csv file with escapeFormulas prefixes formula-triggering values",
     page.locator("button#csv-escape-formulas").click(),
   ]);
 
-  expect(download.suggestedFilename()).toBe(
-    "Best CSV Escaped Formulas.csv",
-  );
+  expect(download.suggestedFilename()).toBe("Best CSV Escaped Formulas.csv");
 
   const path = await download.path();
   const content = readFileSync(path, "utf-8");
@@ -123,9 +121,7 @@ test("download csv file without escapeFormulas leaves formula-triggering values 
     page.locator("button#csv-no-escape-formulas").click(),
   ]);
 
-  expect(download.suggestedFilename()).toBe(
-    "Best CSV Unescaped Formulas.csv",
-  );
+  expect(download.suggestedFilename()).toBe("Best CSV Unescaped Formulas.csv");
 
   const path = await download.path();
   const content = readFileSync(path, "utf-8");

--- a/lib/__specs__/main.spec.ts
+++ b/lib/__specs__/main.spec.ts
@@ -365,6 +365,119 @@ describe("ExportToCsv", () => {
     expect(tsvConf.mediaType).toBe(MediaType.tsv);
   });
 
+  describe("escapeFormulas", () => {
+    it("should prefix values starting with formula trigger characters with a single quote", () => {
+      const options: ConfigOptions = {
+        useBom: false,
+        showColumnHeaders: true,
+        useKeysAsHeaders: true,
+        escapeFormulas: true,
+      };
+
+      const output = asString(
+        generateCsv(options)([
+          {
+            equals: "=1+2",
+            plus: "+1+2",
+            minus: "-1+2",
+            at: "@SUM(A1:A2)",
+            tab: "\t=1+2",
+            carriageReturn: "\r=1+2",
+          },
+        ]),
+      );
+
+      expect(output).toBe(
+        '"equals","plus","minus","at","tab","carriageReturn"\r\n' +
+          '"\'=1+2","\'+1+2","\'-1+2","\'@SUM(A1:A2)","\'\t=1+2","\'\r=1+2"\r\n',
+      );
+    });
+
+    it("should not modify values that don't start with formula trigger characters", () => {
+      const options: ConfigOptions = {
+        useBom: false,
+        showColumnHeaders: true,
+        useKeysAsHeaders: true,
+        escapeFormulas: true,
+      };
+
+      const output = asString(
+        generateCsv(options)([
+          {
+            safe: "hello =1+2",
+            alsoSafe: "1+2=3",
+          },
+        ]),
+      );
+
+      expect(output).toBe(
+        '"safe","alsoSafe"\r\n"hello =1+2","1+2=3"\r\n',
+      );
+    });
+
+    it("should leave formulas unescaped by default", () => {
+      const options: ConfigOptions = {
+        useBom: false,
+        showColumnHeaders: true,
+        useKeysAsHeaders: true,
+      };
+
+      const output = asString(
+        generateCsv(options)([{ formula: "=1+2" }]),
+      );
+
+      expect(output).toBe('"formula"\r\n"=1+2"\r\n');
+    });
+
+    it("should escape formulas even when quoteStrings is false", () => {
+      const options: ConfigOptions = {
+        useBom: false,
+        showColumnHeaders: true,
+        useKeysAsHeaders: true,
+        escapeFormulas: true,
+        quoteStrings: false,
+      };
+
+      const output = asString(
+        generateCsv(options)([{ formula: "=1+2", safe: "hello" }]),
+      );
+
+      expect(output).toBe("formula,safe\r\n'=1+2,hello\r\n");
+    });
+
+    it("should escape formulas produced via replaceUndefinedWith", () => {
+      const options: ConfigOptions = {
+        useBom: false,
+        showColumnHeaders: true,
+        useKeysAsHeaders: true,
+        escapeFormulas: true,
+        replaceUndefinedWith: "=1+2",
+      };
+
+      const output = asString(
+        generateCsv(options)([{ car: "toyota", color: undefined }]),
+      );
+
+      expect(output).toBe('"car","color"\r\n"toyota","\'=1+2"\r\n');
+    });
+
+    it("should not escape numbers or booleans even if escapeFormulas is set", () => {
+      const options: ConfigOptions = {
+        useBom: false,
+        showColumnHeaders: true,
+        useKeysAsHeaders: true,
+        escapeFormulas: true,
+        boolDisplay: { true: "TRUE", false: "FALSE" },
+      };
+
+      const output = asString(
+        generateCsv(options)([{ age: -5, approved: true }]),
+      );
+
+      expect(output).toBe('"age","approved"\r\n-5,TRUE\r\n');
+    });
+  });
+
   describe("asBlob", () => {
     it("should construct a valid blob based on options", async () => {
       const options: ConfigOptions = {

--- a/lib/__specs__/main.spec.ts
+++ b/lib/__specs__/main.spec.ts
@@ -410,9 +410,7 @@ describe("ExportToCsv", () => {
         ]),
       );
 
-      expect(output).toBe(
-        '"safe","alsoSafe"\r\n"hello =1+2","1+2=3"\r\n',
-      );
+      expect(output).toBe('"safe","alsoSafe"\r\n"hello =1+2","1+2=3"\r\n');
     });
 
     it("should leave formulas unescaped by default", () => {
@@ -422,9 +420,7 @@ describe("ExportToCsv", () => {
         useKeysAsHeaders: true,
       };
 
-      const output = asString(
-        generateCsv(options)([{ formula: "=1+2" }]),
-      );
+      const output = asString(generateCsv(options)([{ formula: "=1+2" }]));
 
       expect(output).toBe('"formula"\r\n"=1+2"\r\n');
     });

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -17,6 +17,7 @@ export const defaults: WithDefaults<ConfigOptions> = {
   useKeysAsHeaders: false,
   boolDisplay: { true: "TRUE", false: "FALSE" },
   replaceUndefinedWith: "",
+  escapeFormulas: false,
 };
 
 export const endOfLine = "\r\n";

--- a/lib/generator.ts
+++ b/lib/generator.ts
@@ -6,12 +6,12 @@ import { mkConfig } from "./config.ts";
 import { CsvDownloadEnvironmentError, CsvGenerationError } from "./errors.ts";
 import { addBOM, addBody, addHeaders, addTitle, thread } from "./helpers.ts";
 import {
-  CsvOutput,
-  ConfigOptions,
-  IO,
+  type CsvOutput,
+  type ConfigOptions,
+  type IO,
   mkCsvOutput,
   unpack,
-  AcceptedData,
+  type AcceptedData,
 } from "./types.ts";
 
 /**
@@ -39,7 +39,7 @@ export const generateCsv =
       : withDefaults.columnHeaders;
 
     // Build csv output starting with an empty string
-    let output = thread(
+    const output = thread(
       mkCsvOutput(""),
       addBOM(withDefaults),
       addTitle(withDefaults),

--- a/lib/helpers.ts
+++ b/lib/helpers.ts
@@ -93,7 +93,7 @@ export const addBody =
   ) =>
   (output: CsvOutput): CsvOutput => {
     let body = output;
-    for (var i = 0; i < bodyData.length; i++) {
+    for (let i = 0; i < bodyData.length; i++) {
       let row = mkCsvRow("");
       for (let keyPos = 0; keyPos < headers.length; keyPos++) {
         const header = getHeaderKey(headers[keyPos]);
@@ -119,7 +119,20 @@ export const addBody =
 export const asString = unpack<Newtype<any, string>>;
 
 const isFloat = (input: boolean | string | number): boolean =>
-  +input === input && (!isFinite(input) || Boolean(input % 1));
+  +input === input && (!Number.isFinite(input) || Boolean(input % 1));
+
+const containsFormula = (data: string): boolean => {
+  const reg = new RegExp(/^[=+\-@\t\r]/);
+  return reg.test(data);
+}
+
+const escapeFormulas = (data: string): string => {
+  if (containsFormula(data)) {
+    return `'${data}`;
+  }
+
+  return data;
+}
 
 const formatNumber = (config: ConfigOptions, data: number): FormattedData => {
   if (isFloat(data)) {
@@ -138,6 +151,11 @@ const formatNumber = (config: ConfigOptions, data: number): FormattedData => {
 
 const formatString = (config: ConfigOptions, data: string): FormattedData => {
   let val = data;
+
+  if (config.escapeFormulas) {
+    val = escapeFormulas(data);
+  }
+
   if (
     config.quoteStrings ||
     (config.fieldSeparator && data.indexOf(config.fieldSeparator) > -1) ||
@@ -147,9 +165,10 @@ const formatString = (config: ConfigOptions, data: string): FormattedData => {
   ) {
     val =
       config.quoteCharacter +
-      escapeDoubleQuotes(data, config.quoteCharacter) +
+      escapeDoubleQuotes(val, config.quoteCharacter) +
       config.quoteCharacter;
   }
+
   return mkFormattedData(val);
 };
 
@@ -216,7 +235,7 @@ export const formatData = (
  * See https://www.rfc-editor.org/rfc/rfc4180
  */
 function escapeDoubleQuotes(data: string, quoteCharacter?: string): string {
-  if (quoteCharacter == '"' && data.indexOf('"') > -1) {
+  if (quoteCharacter === '"' && data.indexOf('"') > -1) {
     return data.replace(/"/g, '""');
   }
   return data;

--- a/lib/helpers.ts
+++ b/lib/helpers.ts
@@ -124,7 +124,7 @@ const isFloat = (input: boolean | string | number): boolean =>
 const containsFormula = (data: string): boolean => {
   const reg = new RegExp(/^[=+\-@\t\r]/);
   return reg.test(data);
-}
+};
 
 const escapeFormulas = (data: string): string => {
   if (containsFormula(data)) {
@@ -132,7 +132,7 @@ const escapeFormulas = (data: string): string => {
   }
 
   return data;
-}
+};
 
 const formatNumber = (config: ConfigOptions, data: number): FormattedData => {
   if (isFloat(data)) {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -37,6 +37,7 @@ export type ConfigOptions = {
   useKeysAsHeaders?: boolean;
   boolDisplay?: { true: string; false: string };
   replaceUndefinedWith?: string | boolean | null;
+  escapeFormulas?: boolean;
 };
 
 export type HeaderKey = Newtype<{ readonly HeaderKey: unique symbol }, string>;


### PR DESCRIPTION
Someone brought to light [CWE-1236](https://cwe.mitre.org/data/definitions/1236.html), which would allow people to pass formulas into the exported CSV and then Excel (and others), would possibly open them with the formulas intact. This could lead to various exploits being run on user systems.

While this doesn't fully guard against malicious use, it does at least allow implementers the option to delegate automatically escaping those sequences if they're blindly parsing user-submitted data.

I'm following in the footsteps of the other main libraries and making this option _opt-in_, not opt-out, as the implementer is still responsible for structuring the data themselves _before_ passing it to the library for export--meaning they could do this themselves far before the library ever gets the data.

Issues from other libraries talking about this weakness: 
https://github.com/mholt/PapaParse/issues/793
https://github.com/adaltas/node-csv-stringify/issues/69